### PR TITLE
Network.URI.isUnreserved  is faster

### DIFF
--- a/src/Network/URI/Encode.hs
+++ b/src/Network/URI/Encode.hs
@@ -104,7 +104,7 @@ decodeByteString = U.fromString . decode . U.unpack
 -- following RFC 3986.
 
 isAllowed :: Char -> Bool
-isAllowed c = c `elem` (['A'..'Z'] ++ ['a'..'z'] ++ ['0'..'9'] ++ "-_.~")
+isAllowed = isUnreserved
 
 -------------------------------------------------------------------------------
 -- | "Fix" a String before encoding. This actually breaks the string,


### PR DESCRIPTION
I found the `isUnreserved` function to be up to 10x faster whilst benchmarking [percent-encoder](https://github.com/dnmfarrell/Percent-Encoder). As it's already in Network.URI it's a drop-in replacement for the `isAllowed` definition.

You might not want to merge this for other reasons but I thought I'd let you know in case.

Thanks



